### PR TITLE
Allow host IP 0.0.0.0 for local development

### DIFF
--- a/dev/settings.py
+++ b/dev/settings.py
@@ -28,7 +28,7 @@ class MinimalDevelopmentBaseConfiguration(
 ):
     DEBUG = True
     SECRET_KEY = 'insecuresecret'
-    ALLOWED_HOSTS = values.ListValue(['localhost', '127.0.0.1'])
+    ALLOWED_HOSTS = values.ListValue(['localhost', '127.0.0.1', '0.0.0.0'])
     INTERNAL_IPS = _AlwaysContains() if _is_docker() else ['127.0.0.1']
 
     OAUTH2_PROVIDER = {


### PR DESCRIPTION
Currently, when running the development setup the Django `ALLOWED_HOSTS` settings make it unable to directly interact with the application running inside the container, because we access the Web application from the host system sending `0.0.0.0` as a host header.