### PR TITLE
Remove text translation support

### DIFF
--- a/auth_style/templates/account/account_inactive.html
+++ b/auth_style/templates/account/account_inactive.html
@@ -1,29 +1,25 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Account Inactive' %}{% endblock %}
+{% block head_title %}Account Inactive{% endblock %}
 
 {% block content %}
 <div class="alert alert-error">
   <div class="flex-1 items-center">
     <i class="ri-error-warning-line mr-4 text-4xl"></i>
     <label>
-      {% trans 'Error: Account Inactive' %}
+      Error: Account Inactive
     </label>
   </div>
 </div>
 
 <div class="pb-2 pt-5">
   <p class="mb-5">
-    {% blocktrans trimmed %}
     For more information, you may contact an admin.
     If you think you've received this message in error, try to log in again.
-    {% endblocktrans %}
   </p>
   <p class="text-right">
     <a href="{% url 'account_email' %}" class="btn btn-primary inline-flex items-center is-primary">
-      {% trans 'Log In' %}
+      Log In
       <i class="ri-arrow-right-circle-line ml-3 text-xl"></i>
     </a>
   </p>

--- a/auth_style/templates/account/email.html
+++ b/auth_style/templates/account/email.html
@@ -1,17 +1,13 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'E-mail Addresses' %}{% endblock %}
+{% block head_title %}E-mail Addresses{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'E-mail Addresses' %}</h3>
+<h3 class="mb-2">E-mail Addresses</h3>
 
 {% if user.emailaddress_set.all %}
 <p>
-  {% blocktrans trimmed %}
   The following e-mail addresses are associated with your account:
-  {% endblocktrans %}
 </p>
 
 <form action="{% url 'account_email' %}" class="email_list" method="post">
@@ -33,12 +29,12 @@
         <div>
           {% if emailaddress.verified %}
           <span class="verified border bg-gray-100 mx-1 px-2 py-1 rounded-full text-gray-500 text-3xs">
-            {% trans 'verified' %}
+            verified
           </span>
           {% else %}
           <span class="unverified border bg-gray-100 flex items-center mx-1 pl-1 pr-2 rounded-full text-gray-500 text-3xs">
             <i class="ri-error-warning-line mr-1 text-sm text-red-600"></i>
-            {% trans 'unverified' %}
+            unverified
           </span>
           {% endif %}
         </div>
@@ -48,14 +44,14 @@
 
     <div class="buttonHolder flex items-center py-5">
       <button class="primaryAction btn btn-error text-white btn-xs rounded-md" name="action_remove">
-        {% trans 'Remove' %}
+        Remove
       </button>
       <div class="spacer flex-grow"></div>
       <button class="secondaryAction btn btn-outline mr-1 btn-xs rounded-md" name="action_send">
-        {% trans 'Re-send Verification' %}
+        Re-send Verification
       </button>
       <button class="secondaryAction btn btn-primary btn-xs rounded-md" name="action_primary">
-        {% trans 'Make Primary' %}
+        Make Primary
       </button>
     </div>
   </fieldset>
@@ -64,23 +60,21 @@
 <div class="bg-red-500 flex items-center justify-between m-4 px-5 py-4 rounded-lg text-white">
   <i class="ri-error-warning-line mr-4 text-4xl"></i>
   <div>
-    <strong>{% trans 'Warning'%}:</strong>
-    {% blocktrans trimmed %}
+    <strong>Warning:</strong>
     You currently do not have any e-mail address set up.
     You should really add an e-mail address so you can receive notifications, reset your password, etc.
-    {% endblocktrans %}
   </div>
 </div>
 {% endif %}
 
 <div class="bg-gray-100 border border-gray-300 mt-3 -mx-3 p-5 rounded-lg">
-  <h5>{% trans 'Add E-mail Address' %}</h5>
+  <h5>Add E-mail Address</h5>
   <form method="post" action="{% url 'account_email' %}" class="add_email flex !items-end">
     {% csrf_token %}
     {{ form.as_p }}
     <p class="ml-2 max-w-fit">
       <button class="btn btn-primary" name="action_add">
-        {% trans 'Add E-mail' %}
+        Add E-mail
       </button>
     </p>
   </form>
@@ -90,7 +84,7 @@
 {% block extra_body %}
 <script type="text/javascript">
   (function () {
-    const message = "{% trans 'Do you really want to remove the selected e-mail address?' %}";
+    const message = "Do you really want to remove the selected e-mail address?";
     const actions = document.getElementsByName('action_remove');
     if (actions.length) {
       actions[0].addEventListener('click', function (e) {

--- a/auth_style/templates/account/email_confirm.html
+++ b/auth_style/templates/account/email_confirm.html
@@ -1,52 +1,43 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
 {% load account %}
 
-{% block head_title %}{% trans 'Confirm E-mail Address' %}{% endblock %}
+{% block head_title %}Confirm E-mail Address{% endblock %}
 
 {% block content %}
-<h3 class="card-title mb-2">{% trans 'Confirm E-mail Address' %}</h3>
+<h3 class="card-title mb-2">Confirm E-mail Address</h3>
 
 {% if confirmation %}
 
-{% user_display confirmation.email_address.user as user_display %}
 <p>
-  {% blocktrans trimmed with email=confirmation.email_address.email %}
-  Please confirm that <a href="mailto:{{ email }}" class="link-accent">{{ email }}</a>
-  is an e-mail address for user {{ user_display }}.
-  {% endblocktrans %}
+  Please confirm that <a href="mailto:{{ confirmation.email_address.email }}" class="link-accent">{{ confirmation.email_address.email }}</a>
+  is an e-mail address for user {% user_display confirmation.email_address.user %}.
 </p>
 
 <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
   {% csrf_token %}
   <button class="btn btn-primary">
-    {% trans 'Confirm' %}
+    Confirm
   </button>
 </form>
 
 {% else %}
 
-{% url 'account_email' as email_url %}
 <div class="alert alert-error mb-4">
   <div class="flex-1 items-center">
     <i class="ri-error-warning-line mr-4 text-4xl"></i>
     <label>
-      {% blocktrans trimmed %}
       Link expired or invalid.
-      {% endblocktrans %}
     </label>
   </div>
 </div>
 
-{% blocktrans trimmed %}
 This confirmation link is expired or invalid.
 Please issue a new e-mail confirmation request.
-{% endblocktrans %}
 
 <div class="flex justify-end mt-4">
-  <a href="{{ email_url }}" class="btn btn-primary">
-    {% trans 'New Request' %}
+  <a href="{% url 'account_email' %}" class="btn btn-primary">
+    New Request
   </a>
 </div>
 {% endif %}

--- a/auth_style/templates/account/login.html
+++ b/auth_style/templates/account/login.html
@@ -1,20 +1,17 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
 {% load account socialaccount %}
 
-{% block head_title %}{% trans 'Sign In' %}{% endblock %}
+{% block head_title %}Sign In{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Sign In' %}</h3>
+<h3 class="mb-2">Sign In</h3>
 
 {% get_providers as socialaccount_providers %}
 {% if socialaccount_providers %}
 <p>
-  {% blocktrans trimmed %}
   Please sign in with one of your existing third party accounts.
   Or, sign in using your email address below. If you don't have an account, please <a href="{{ signup_url }}" class="link-accent">sign up</a> for one.
-  {% endblocktrans %}
 </p>
 <div class="socialaccount_ballot border border-gray-200 card bg-gray-100 my-3">
   <div class="card-body p-6">
@@ -26,14 +23,12 @@
 </div>
 
 <div class="divider">
-  {% trans 'OR' %}
+  OR
 </div>
 
 {% else %}
 <p class="border-b border-gray-300 mb-3 pb-5">
-  {% blocktrans trimmed %}
   If you have not created an account yet, then please <a href="{{ signup_url }}" class="link-accent">sign up</a> first.
-  {% endblocktrans %}
 </p>
 {% endif %}
 
@@ -45,10 +40,10 @@
   {% endif %}
   <div class="flex items-center justify-between pb-0 pt-5">
     <a class="secondaryAction link-accent" href="{% url 'account_reset_password' %}">
-      {% trans 'Forgot Password?' %}
+      Forgot Password?
     </a>
     <button class="inline-flex items-center btn btn-primary primaryAction">
-      {% trans 'Sign In' %}
+      Sign In
       <i class="ri-arrow-right-circle-line ml-3 text-xl"></i>
     </button>
   </div>

--- a/auth_style/templates/account/logout.html
+++ b/auth_style/templates/account/logout.html
@@ -1,16 +1,12 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Sign Out' %}{% endblock %}
+{% block head_title %}Sign Out{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Sign Out' %}</h3>
+<h3 class="mb-2">Sign Out</h3>
 
 <p>
-  {% blocktrans trimmed %}
   Are you sure you want to sign out?
-  {% endblocktrans %}
 </p>
 
 <form method="post" action="{% url 'account_logout' %}">
@@ -20,7 +16,7 @@
   {% endif %}
   <div class="flex justify-end">
     <button class="btn btn-primary">
-      {% trans 'Sign Out' %}
+      Sign Out
     </button>
   </div>
 </form>

--- a/auth_style/templates/account/password_change.html
+++ b/auth_style/templates/account/password_change.html
@@ -1,18 +1,16 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Change Password' %}{% endblock %}
+{% block head_title %}Change Password{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Change Password' %}</h3>
+<h3 class="mb-2">Change Password</h3>
 
 <form method="POST" action="{% url 'account_change_password' %}" class="password_change">
   {% csrf_token %}
   {{ form.as_p }}
   <div class="flex justify-end pb-0 pt-5">
     <button class="btn btn-primary" name="action">
-      {% trans 'Change Password' %}
+      Change Password
     </button>
   </div>
 </form>

--- a/auth_style/templates/account/password_reset.html
+++ b/auth_style/templates/account/password_reset.html
@@ -1,27 +1,22 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
 {% load account %}
 
-{% block head_title %}{% trans 'Password Reset' %}{% endblock %}
+{% block head_title %}Password Reset{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Password Reset' %}</h3>
+<h3 class="mb-2">Password Reset</h3>
 {% if user.is_authenticated %}
 {% include "account/snippets/already_logged_in.html" %}
 {% endif %}
 
 <p class="mb-3">
-  {% blocktrans trimmed %}
   Forgot your password?
   Enter your e-mail address below, and we'll send you an e-mail containing a link to reset it.
-  {% endblocktrans %}
 </p>
 
 <p class="mb-3">
-  {% blocktrans trimmed %}
   Please contact us if you have any trouble resetting your password.
-  {% endblocktrans %}
 </p>
 
 <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
@@ -29,7 +24,7 @@
   {{ form.as_p }}
   <div class="flex justify-end pb-0 pt-5">
     <button class="btn btn-primary">
-      {% trans 'Reset My Password' %}
+      Reset My Password
     </button>
   </div>
 </form>

--- a/auth_style/templates/account/password_reset_done.html
+++ b/auth_style/templates/account/password_reset_done.html
@@ -1,21 +1,18 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
 {% load account %}
 
-{% block head_title %}{% trans 'Password Reset' %}{% endblock %}
+{% block head_title %}Password Reset{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Password Reset' %}</h3>
+<h3 class="mb-2">Password Reset</h3>
 
 {% if user.is_authenticated %}
 {% include "account/snippets/already_logged_in.html" %}
 {% endif %}
 
 <p>
-  {% blocktrans trimmed %}
   We have sent you an e-mail.
   Please contact us if you do not receive it within a few minutes.
-  {% endblocktrans %}
 </p>
 {% endblock %}

--- a/auth_style/templates/account/password_reset_from_key.html
+++ b/auth_style/templates/account/password_reset_from_key.html
@@ -1,28 +1,24 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Change Password' %}{% endblock %}
+{% block head_title %}Change Password{% endblock %}
 
 {% block content %}
 {% if token_fail %}
 <div class="alert alert-error mb-4">
   <div class="flex-1 items-center">
     <i class="ri-error-warning-line mr-4 text-4xl"></i>
-    <label>{% trans 'Bad Token' %}</label>
+    <label>Bad Token</label>
   </div>
 </div>
 {% else %}
-<h3 class="mb-2">{% trans 'Change Password' %}</h3>
+<h3 class="mb-2">Change Password</h3>
 {% endif %}
 
 {% if token_fail %}
 {% url 'account_reset_password' as passwd_reset_url %}
 <p>
-  {% blocktrans trimmed %}
   The password reset link was invalid, possibly because it has already been used.
   Please request a <a href="{{ passwd_reset_url }}" class="link-accent">new password reset</a>.
-  {% endblocktrans %}
 </p>
 {% elif form %}
 <form method="POST" action="{{ action_url }}">
@@ -30,15 +26,13 @@
   {{ form.as_p }}
   <div class="flex justify-end pb-0 pt-5">
     <button class="btn btn-primary" name="action">
-      {% trans 'Change Password' %}
+      Change Password
     </button>
   </div>
 </form>
 {% else %}
 <p>
-  {% blocktrans trimmed %}
   Your password is now changed.
-  {% endblocktrans %}
 </p>
 {% endif %}
 

--- a/auth_style/templates/account/password_reset_from_key_done.html
+++ b/auth_style/templates/account/password_reset_from_key_done.html
@@ -1,15 +1,11 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Change Password' %}{% endblock %}
+{% block head_title %}Change Password{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Change Password' %}</h3>
+<h3 class="mb-2">Change Password</h3>
 
 <p>
-  {% blocktrans trimmed %}
   Your password is now changed.
-  {% endblocktrans %}
 </p>
 {% endblock %}

--- a/auth_style/templates/account/password_set.html
+++ b/auth_style/templates/account/password_set.html
@@ -1,18 +1,16 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Set Password' %}{% endblock %}
+{% block head_title %}Set Password{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Set Password' %}</h3>
+<h3 class="mb-2">Set Password</h3>
 
 <form method="POST" action="{% url 'account_set_password' %}" class="password_set">
   {% csrf_token %}
   {{ form.as_p }}
   <div class="flex justify-end pb-0 pt-5">
     <button class="btn btn-primary" name="action">
-      {% trans 'Set Password' %}
+      Set Password
     </button>
   </div>
 </form>

--- a/auth_style/templates/account/signup.html
+++ b/auth_style/templates/account/signup.html
@@ -1,17 +1,13 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Sign Up' %}{% endblock %}
+{% block head_title %}Sign Up{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Sign Up' %}</h3>
+<h3 class="mb-2">Sign Up</h3>
 
 <p class="border-b border-gray-300 mb-3 pb-5">
-  {% blocktrans trimmed %}
   Already have an account?
   Then please <a href="{{ login_url }}" class="link-accent">sign in</a>.
-  {% endblocktrans %}
 </p>
 
 <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
@@ -22,7 +18,7 @@
   {% endif %}
   <div class="flex justify-end pb-0 pt-5">
     <button class="inline-flex items-center btn btn-primary">
-      {% trans 'Sign Up' %}
+      Sign Up
       <i class="ri-arrow-right-circle-line ml-3 text-xl"></i>
     </button>
   </div>

--- a/auth_style/templates/account/signup_closed.html
+++ b/auth_style/templates/account/signup_closed.html
@@ -1,15 +1,11 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Sign Up Closed' %}{% endblock %}
+{% block head_title %}Sign Up Closed{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Sign Up Closed' %}</h3>
+<h3 class="mb-2">Sign Up Closed</h3>
 
 <p>
-  {% blocktrans trimmed %}
   We are sorry, but the sign up is currently closed.
-  {% endblocktrans %}
 </p>
 {% endblock %}

--- a/auth_style/templates/account/snippets/already_logged_in.html
+++ b/auth_style/templates/account/snippets/already_logged_in.html
@@ -1,15 +1,11 @@
-{% load i18n %}
 {% load account %}
 
-{% user_display user as user_display %}
 <div class="alert alert-warning mb-4">
   <div class="flex-1">
     <i class="ri-information-line mr-4 text-4xl"></i>
     <p>
-      <strong class="mr-1">{% trans 'Note' %}:</strong>
-      {% blocktrans trimmed %}
-      you are already logged in as {{ user_display }}.
-      {% endblocktrans %}
+      <strong class="mr-1">Note:</strong>
+      you are already logged in as {% user_display user %}.
     </p>
   </div>
 </div>

--- a/auth_style/templates/account/verification_sent.html
+++ b/auth_style/templates/account/verification_sent.html
@@ -1,17 +1,13 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Verify Your E-mail Address' %}{% endblock %}
+{% block head_title %}Verify Your E-mail Address{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Verify Your E-mail Address' %}</h3>
+<h3 class="mb-2">Verify Your E-mail Address</h3>
 
 <p>
-  {% blocktrans trimmed %}
   We have sent an e-mail to you for verification.
   Follow the link provided to finalize the signup process.
   Please contact us if you do not receive it within a few minutes.
-  {% endblocktrans %}
 </p>
 {% endblock %}

--- a/auth_style/templates/account/verified_email_required.html
+++ b/auth_style/templates/account/verified_email_required.html
@@ -1,37 +1,27 @@
 {% extends 'account/base.html' %}
 
-{% load i18n %}
-
-{% block head_title %}{% trans 'Verify Your E-mail Address' %}{% endblock %}
+{% block head_title %}Verify Your E-mail Address{% endblock %}
 
 {% block content %}
-<h3 class="mb-2">{% trans 'Verify Your E-mail Address' %}</h3>
-
-{% url 'account_email' as email_url %}
+<h3 class="mb-2">Verify Your E-mail Address</h3>
 
 <p>
-  {% blocktrans trimmed %}
   This part of the site requires us to verify that you are who you claim to be.
   For this purpose, we require that you verify ownership of your e-mail address.
-  {% endblocktrans %}
 </p>
 
 <p>
-  {% blocktrans trimmed %}
   We have sent an e-mail to you for verification.
   Please click on the link inside this e-mail.
   Please contact us if you do not receive it within a few minutes.
-  {% endblocktrans %}
 </p>
 
 <div class="alert alert-warning mt-4">
   <div class="flex-1 items-center">
     <i class="ri-information-line mr-4 text-4xl"></i>
     <label>
-      <strong>{% trans 'Note' %}:</strong>
-      {% blocktrans trimmed %}
-      you can still <a href="{{ email_url }}" class="link">change your e-mail address</a>.
-      {% endblocktrans %}
+      <strong>Note:</strong>
+      you can still <a href="{% url 'account_email' %}" class="link">change your e-mail address</a>.
     </label>
   </div>
 </div>

--- a/auth_style/templates/socialaccount/snippets/provider_list.html
+++ b/auth_style/templates/socialaccount/snippets/provider_list.html
@@ -1,4 +1,3 @@
-{% load i18n %}
 {% load socialaccount %}
 {% load static %}
 
@@ -23,7 +22,7 @@
      class="socialaccount_provider {{provider.id}} block btn flex btn-sm text-[11px] items-center"
      href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
     <i class="ri-{{ provider.id }}-fill mr-3 text-[18px]"></i>
-    {% trans 'Sign in with' %} {{provider.name}}
+    Sign in with {{provider.name}}
   </a>
 </li>
 {% endfor %}


### PR DESCRIPTION
There's no testing to ensure that the exact wording of templates continues to match the upstream translations.

Also, attempting to support translation prevents adding or rewording text that might improve usability.