### PR TITLE
Remove email template overrides

### DIFF
--- a/auth_style/templates/account/email/base_message.txt
+++ b/auth_style/templates/account/email/base_message.txt
@@ -1,7 +1,0 @@
-{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name %}Hello from {{ site_name }}!{% endblocktrans %}
-
-{% block content %}{% endblock %}
-
-{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you for using {{ site_name }}!
-{{ site_domain }}{% endblocktrans %}
-{% endautoescape %}

--- a/auth_style/templates/account/email/email_confirmation_message.txt
+++ b/auth_style/templates/account/email/email_confirmation_message.txt
@@ -1,7 +1,0 @@
-{% extends "account/email/base_message.txt" %}
-{% load account %}
-{% load i18n %}
-
-{% block content %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this e-mail because user {{ user_display }} has given your e-mail address to register an account on {{ site_domain }}.
-
-To confirm this is correct, go to {{ activate_url }}{% endblocktrans %}{% endautoescape %}{% endblock %}

--- a/auth_style/templates/account/email/email_confirmation_signup_message.txt
+++ b/auth_style/templates/account/email/email_confirmation_signup_message.txt
@@ -1,1 +1,0 @@
-{% include "account/email/email_confirmation_message.txt" %}

--- a/auth_style/templates/account/email/email_confirmation_signup_subject.txt
+++ b/auth_style/templates/account/email/email_confirmation_signup_subject.txt
@@ -1,1 +1,0 @@
-{% include "account/email/email_confirmation_subject.txt" %}

--- a/auth_style/templates/account/email/email_confirmation_subject.txt
+++ b/auth_style/templates/account/email/email_confirmation_subject.txt
@@ -1,4 +1,0 @@
-{% load i18n %}
-{% autoescape off %}
-{% blocktrans %}Please Confirm Your E-mail Address{% endblocktrans %}
-{% endautoescape %}

--- a/auth_style/templates/account/email/password_reset_key_message.txt
+++ b/auth_style/templates/account/email/password_reset_key_message.txt
@@ -1,9 +1,0 @@
-{% extends "account/email/base_message.txt" %}
-{% load i18n %}
-
-{% block content %}{% autoescape off %}{% blocktrans %}You're receiving this e-mail because you or someone else has requested a password for your user account.
-It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
-
-{{ password_reset_url }}{% if username %}
-
-{% blocktrans %}In case you forgot, your username is {{ username }}.{% endblocktrans %}{% endif %}{% endautoescape %}{% endblock %}

--- a/auth_style/templates/account/email/password_reset_key_subject.txt
+++ b/auth_style/templates/account/email/password_reset_key_subject.txt
@@ -1,4 +1,0 @@
-{% load i18n %}
-{% autoescape off %}
-{% blocktrans %}Password Reset E-mail{% endblocktrans %}
-{% endautoescape %}


### PR DESCRIPTION
These are the same as the upstream versions and there is currently no need to further style or customize them.